### PR TITLE
fix(*): don't truncate empty lines in decoder.

### DIFF
--- a/lib/ethereum/decoder.rb
+++ b/lib/ethereum/decoder.rb
@@ -57,7 +57,7 @@ module Ethereum
     end
 
     def decode_static_bytes(value, subtype = nil, start = 0)
-      trim(value, start, subtype.to_i*8).scan(/.{2}/).collect {|x| x.hex}.pack('C*').strip
+      trim(value, start, subtype.to_i*8).scan(/.{2}/).collect {|x| x.hex}.pack('C*')
     end
 
     def decode_dynamic_bytes(value, start = 0)
@@ -76,7 +76,7 @@ module Ethereum
       types.each.with_index.map { |t , i| decode(t, data, i*64) }
     end
 
-    private 
+    private
       def trim(value, start, bitsize = 256)
         value[start+63-(bitsize/4-1)..start+63]
       end

--- a/lib/ethereum/version.rb
+++ b/lib/ethereum/version.rb
@@ -1,3 +1,3 @@
 module Ethereum
-  VERSION = "2.2.2"
+  VERSION = "2.2.3"
 end


### PR DESCRIPTION
0x0a9f1cc6ddccc8b60e30587731d52238b1482bf5bc2c719de712daa59305cd9c
caused
9f1cc6ddccc8b60e30587731d52238b1482bf5bc2c719de712daa59305cd9c
because '0a' transformed to '\n'